### PR TITLE
Change timezone to summer time

### DIFF
--- a/data/grading-and-exams.md
+++ b/data/grading-and-exams.md
@@ -38,6 +38,8 @@ You may take part in any number of the exams listed above. The highest grade ach
 
 ## Information about exam arrangements
 
+<notice>All times are local time in Helsinki, Finland, UTC+03:00</notice>
+
 * You do not need to enrol for the exam.
 * The course exam can be taken on exam date **between 10:00 AM and 10:00 PM**.
 * The exam ends at 10:00 PM at the latest. If you want to be able to spend the maximum time allowed on the exam, you should **start at 6:00 PM at the latest**.

--- a/data/support-and-assistance.md
+++ b/data/support-and-assistance.md
@@ -18,7 +18,7 @@ The course channels are available through [this link](https://study.cs.helsinki.
 
 <notice>The times indicated below may change as the course progresses.</notice>
 
-<notice>All times are local time in Helsinki, Finland, UTC+02:00</notice>
+<notice>All times are local time in Helsinki, Finland, UTC+03:00</notice>
 
 The workshop will be held **on Wednesdays from 12:00 to 16:00 in classroom BK107**
 
@@ -36,7 +36,7 @@ A team of course instructors is available on multiple days every week to help yo
 
 In the table below the symbol <svg class="svg-inline--fa fa-comment fa-w-14 fa-1x" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M256 32C114.6 32 0 125.1 0 240c0 49.6 21.4 95 57 130.7C44.5 421.1 2.7 466 2.2 466.5c-2.2 2.3-2.8 5.7-1.5 8.7S4.8 480 8 480c66.3 0 116-31.8 140.6-51.4 32.7 12.3 69 19.4 107.4 19.4 141.4 0 256-93.1 256-208S397.4 32 256 32z"/></svg>&nbsp; means instructors are only available on the text-based channels `ohjelmoinnin_mooc_general` and `ohjelmoinnin_mooc_english`. The symbol <svg  class="svg-inline--fa fa-volume-up fa-w-14 fa-1x" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M215.03 71.05L126.06 160H24c-13.26 0-24 10.74-24 24v144c0 13.25 10.74 24 24 24h102.06l88.97 88.95c15.03 15.03 40.97 4.47 40.97-16.97V88.02c0-21.46-25.96-31.98-40.97-16.97zm233.32-51.08c-11.17-7.33-26.18-4.24-33.51 6.95-7.34 11.17-4.22 26.18 6.95 33.51 66.27 43.49 105.82 116.6 105.82 195.58 0 78.98-39.55 152.09-105.82 195.58-11.17 7.32-14.29 22.34-6.95 33.5 7.04 10.71 21.93 14.56 33.51 6.95C528.27 439.58 576 351.33 576 256S528.27 72.43 448.35 19.97zM480 256c0-63.53-32.06-121.94-85.77-156.24-11.19-7.14-26.03-3.82-33.12 7.46s-3.78 26.21 7.41 33.36C408.27 165.97 432 209.11 432 256s-23.73 90.03-63.48 115.42c-11.19 7.14-14.5 22.07-7.41 33.36 6.51 10.36 21.12 15.14 33.12 7.46C447.94 377.94 480 319.54 480 256zm-141.77-76.87c-11.58-6.33-26.19-2.16-32.61 9.45-6.39 11.61-2.16 26.2 9.45 32.61C327.98 228.28 336 241.63 336 256c0 14.38-8.02 27.72-20.92 34.81-11.61 6.41-15.84 21-9.45 32.61 6.43 11.66 21.05 15.8 32.61 9.45 28.23-15.55 45.77-45 45.77-76.88s-17.54-61.32-45.78-76.86z"/></svg>&nbsp; means instructors are available both on the text-based channels and on the voice channel `ohjelmoinnin_mooc_voice`.
 
-<notice>The times indicated below may change as the course progresses. All times are local time in Helsinki, Finland, UTC+02:00</notice>
+<notice>The times indicated below may change as the course progresses. All times are local time in Helsinki, Finland, UTC+03:00</notice>
 
 <table>
   <thead>


### PR DESCRIPTION
Fixed timezones to match summer time UTC+03:00 in `support-and-assistance.md` and added same timezone notice as previous to `grading-and-exams.md`.