### PR TITLE
Added a link to previous leap years exercise

### DIFF
--- a/data/part-2/4-simple-loops.md
+++ b/data/part-2/4-simple-loops.md
@@ -415,7 +415,7 @@ Correct! It only took you one single attempt!
 
 Please write a program which asks the user for a year, and prints out the next leap year.
     
-*<a href="https://programming-22.mooc.fi/part-2/3-combining-conditions#programming-exercise-leap-year" target="_blank">Click here if you forgot how to check if a year is leap or not?</a>?*
+*<a href="https://programming-22.mooc.fi/part-2/3-combining-conditions#programming-exercise-leap-year" target="_blank">Click here if you forgot how to check if a year is leap or not.</a>?*
 
 <sample-output>
 

--- a/data/part-2/4-simple-loops.md
+++ b/data/part-2/4-simple-loops.md
@@ -414,6 +414,8 @@ Correct! It only took you one single attempt!
 <in-browser-programming-exercise name="The next leap year" tmcname="part02-20_next_leap_year">
 
 Please write a program which asks the user for a year, and prints out the next leap year.
+    
+*<a href="https://programming-22.mooc.fi/part-2/3-combining-conditions#programming-exercise-leap-year" target="_blank">Click here if you forgot how to check if a year is leap or not?</a>?*
 
 <sample-output>
 

--- a/data/part-2/4-simple-loops.md
+++ b/data/part-2/4-simple-loops.md
@@ -415,7 +415,7 @@ Correct! It only took you one single attempt!
 
 Please write a program which asks the user for a year, and prints out the next leap year.
     
-*<a href="https://programming-22.mooc.fi/part-2/3-combining-conditions#programming-exercise-leap-year" target="_blank">Click here if you forgot how to check if a year is leap or not.</a>?*
+*<a href="https://programming-22.mooc.fi/part-2/3-combining-conditions#programming-exercise-leap-year" target="_blank">Click here if you forgot how to check if a year is leap or not.</a>*
 
 <sample-output>
 


### PR DESCRIPTION
In the instructions for exercise "The next leap year", added an internal link to part 2-3 "Leap year" exercise to make it easier to be reminded of how to check if a year is leap or not. It should open in a new tab (if supported by the html processor),  and be sufficiently meaningful to make it accessible.