### PR TITLE
Fixing a typo

### DIFF
--- a/data/part-7/3-times-and-dates.md
+++ b/data/part-7/3-times-and-dates.md
@@ -139,7 +139,7 @@ print("32 weeks and 15 days after Midsummer it will be", midsummer + long_time)
 <sample-output>
 
 A week after Midsummer it will be 2021-07-03 00:00:00
-32 weeks and 15 days after Midsummer it will be 2021-02-20 00:00:00
+32 weeks and 15 days after Midsummer it will be 2022-02-20 00:00:00
 
 </sample-output>
 


### PR DESCRIPTION
The output of the following code `print("32 weeks and 15 days after Midsummer it will be", midsummer + long_time)`should be
32 weeks and 15 days after Midsummer it will be 2022-02-20 00:00:00 and not 32 weeks and 15 days after Midsummer it will be 2021-02-20 00:00:00