### PR TITLE
Fixed typo in Part 9, Section 5

### DIFF
--- a/data/part-9/5-class-attributes.md
+++ b/data/part-9/5-class-attributes.md
@@ -309,7 +309,7 @@ This is a valid license plate!
 
 </sample-output>
 
-The validity of a license plate can be checked even without creating a single instance of the class, for example with `Registration.license_plate_valid("xyz-789"))`. The same method is called within the constructor of the class. NB: even within the constructor this method is accessed through the name of the class, not `self`!
+The validity of a license plate can be checked even without creating a single instance of the class, for example with `Registration.license_plate_valid("xyz-789")`. The same method is called within the constructor of the class. NB: even within the constructor this method is accessed through the name of the class, not `self`!
 
 <programming-exercise name='List helper' tmcname='part09-14_list_helper'>
 


### PR DESCRIPTION
Fixed typo in Part 9, Section 5, Heading - Class methods, paragraph 5, line number 2.