### PR TITLE
Fix typo in part 6-1

### DIFF
--- a/data/part-6/1-reading-files.md
+++ b/data/part-6/1-reading-files.md
@@ -641,7 +641,7 @@ When you have verified your program works correctly, you can remove the `if` str
 Let's expand the program created in the previous exercise. Now also the exam points awarded to each student are contained in a CSV file. The contents of the file follow this format:
 
 ```csv
-opnro;k1;k2;k3
+id;e1;e2;e3
 12345678;4;1;4
 12345687;3;5;3
 12345699;10;2;2


### PR DESCRIPTION
With **Course grading, part 2 exercise**, there seems to be some Finnish abbreviations left in.

Correcting `opnro;k1;k2;k3` to `id;e1;e2;e3` so that they are in line with the other exercises.