### PR TITLE
Fixed SyntaxError in Part 4, Section 3

### DIFF
--- a/data/part-4/3-lists.md
+++ b/data/part-4/3-lists.md
@@ -389,7 +389,7 @@ Notice how the method modifies the list itself. Sometimes we don't want to chang
 
 ```python
 my_list = [2,5,1,2,4]
-print(sorted(my_list)))
+print(sorted(my_list))
 ```
 
 <sample-output>


### PR DESCRIPTION
Fixed `SyntaxError: unmatched ')'` in Part 4, Section 3, Heading - Sorting lists, Code segment 2, Line number 2.