### PR TITLE
Fixed SyntaxError in Part 4, Section 3

### DIFF
--- a/data/part-4/3-lists.md
+++ b/data/part-4/3-lists.md
@@ -523,7 +523,7 @@ Just like the built-in functions above, our own functions can also take a list a
 
 ```python
 def median(my_list: list):
-    ordered = sorted(my_list))
+    ordered = sorted(my_list)
     list_centre = len(ordered) // 2
     return ordered[list_centre]
 ```


### PR DESCRIPTION
Fixed `SyntaxError: unmatched ')'` in Part 4, Section 3, Heading - A list as an argument or a return value, Code segment 1, Line number 2.