### PR TITLE
Fix Incorrect Example code

### DIFF
--- a/data/part-11/1-list-comprehensions.md
+++ b/data/part-11/1-list-comprehensions.md
@@ -476,7 +476,7 @@ The method should use a list comprehension to achieve this. The maximum length o
 Please take a look at the example below:
 
 ```python
-week8 = LotteryNumbers(8, [1,2,3,10,20,30,33])
+week8 = LotteryNumbers(8, [1,2,3,10,15,20,30])
 my_numbers = [1,4,7,10,11,20,30]
 
 print(week8.hits_in_place(my_numbers))


### PR DESCRIPTION
original array argument for LotteryNumbers constructor was `[1,2,3,10,20,30,33]`, then means that week8.hits_in_place(my_numbers) with `my_numbers = [1,4,7,10,11,20,30]` would result in `[1, -1, -1, 10, -1, -1, -1]` instead of `[1, -1, -1, 10, -1, 20, 30]`. Changed the passed in value for LotteryNumbers constructor to `week8 = LotteryNumbers(8, [1,2,3,10,15,20,30])` which would make the current sample output of `[1, -1, -1, 10, -1, 20, 30]` correct

The context of the question is we want to produce a new array and compare 2 arrays, if value is the same value and index, just put the value in a new array, else, put -1